### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-update-using-golang.yml
+++ b/.github/workflows/auto-update-using-golang.yml
@@ -1,6 +1,9 @@
 # Name of the GitHub Actions workflow
 name: Run Go Script and Push Changes
 
+permissions:
+  contents: write
+
 # Define the events that trigger this workflow
 on:
   # Run automatically on a schedule (daily at midnight UTC)


### PR DESCRIPTION
Potential fix for [https://github.com/Strong-Foundation/uschemical-com-documentation/security/code-scanning/1](https://github.com/Strong-Foundation/uschemical-com-documentation/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves reading repository contents and pushing changes, we need `contents: read` and `contents: write` permissions. These permissions can be added at the root level of the workflow to apply to all jobs or within the specific job (`build`) to limit the scope further.

The best approach is to add the `permissions` block at the root level of the workflow, as this workflow has only one job. This ensures clarity and avoids redundancy.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
